### PR TITLE
Fix replaying same song if Repeat is off and Skip button is pressed while on the last song in the list

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -675,7 +675,11 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                 break;
             default:
             case REPEAT_MODE_NONE:
-                if (isLastTrack()) {
+                if (force) {
+                    if (isLastTrack()) {
+                        position = 0;
+                    }
+                } else {
                     position -= 1;
                 }
                 break;

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -658,31 +658,10 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
     public int getNextPosition(boolean force) {
         int position = getPosition() + 1;
-        switch (getRepeatMode()) {
-            case REPEAT_MODE_ALL:
-                if (isLastTrack()) {
-                    position = 0;
-                }
-                break;
-            case REPEAT_MODE_THIS:
-                if (force) {
-                    if (isLastTrack()) {
-                        position = 0;
-                    }
-                } else {
-                    position -= 1;
-                }
-                break;
-            default:
-            case REPEAT_MODE_NONE:
-                if (force) {
-                    if (isLastTrack()) {
-                        position = 0;
-                    }
-                } else {
-                    position -= 1;
-                }
-                break;
+        if ((getRepeatMode() == REPEAT_MODE_ALL || force) && isLastTrack()) {
+            position = 0;
+        } else {
+            position -= 1;
         }
         return position;
     }


### PR DESCRIPTION
If replay was off and you were playing the last song in the playlist then it would stop at the end. This is intended behaviour. 
However, pressing skip would play the same song again, this is incorrect as it isn't skipping the song back to the start.
Since this fix brought some redundancy in the existing code, I simplified it too (21 lines -> 4 lines)